### PR TITLE
substitute . for - in worker script name

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "cloudflare_workers_kv" "mta_sts" {
 }
 
 resource "cloudflare_worker_script" "mta_sts_policy" {
-  name    = "mta-sts.${var.zone_name}"
+  name    = "mta-sts-${replace(var.zone_name, ".", "-")}"
   content = file("${path.module}/mta_sts.js")
 
   kv_namespace_binding {


### PR DESCRIPTION
Encountered `workers.api.error.invalid_script_name` in an attempt to deploy.