### PR TITLE
set worker at the root path

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -17,6 +17,20 @@ resource "cloudflare_record" "mta_sts" {
   value   = "v=STSv1; id=${local.policy_id}"
 }
 
+resource "cloudflare_record" "a" {
+  zone_id = var.zone_id
+  name    = "mta-sts"
+  type    = "A"
+  value   = "192.0.2.1"
+}
+
+resource "cloudflare_record" "aaaa" {
+  zone_id = var.zone_id
+  name    = "mta-sts"
+  type    = "AAAA"
+  value   = "100:::"
+}
+
 resource "cloudflare_workers_kv_namespace" "mta_sts" {
   title = "mta-sts.${var.zone_name}"
 }
@@ -37,8 +51,8 @@ resource "cloudflare_worker_script" "mta_sts_policy" {
   }
 }
 
-resource "cloudflare_worker_route" "my_route" {
+resource "cloudflare_worker_route" "mta_sts" {
   zone_id     = var.zone_id
-  pattern     = "mta-sts.${var.zone_name}/.well-known/mta-sts.txt"
+  pattern     = "mta-sts.${var.zone_name}/*"
   script_name = cloudflare_worker_script.mta_sts_policy.name
 }

--- a/mta_sts.js
+++ b/mta_sts.js
@@ -3,10 +3,16 @@ addEventListener("fetch", event => {
 })
 
 async function handleRequest(request) {
-  const value = await POLICY_NAMESPACE.get("policy")
-  if (value === null) {
-    return new Response("Policy not found", { status: 404 })
+  const url = new URL(request.url)
+  let response = null
+
+  if (url.pathname === '/.well-known/mta-sts.txt') {
+    response = await POLICY_NAMESPACE.get("policy")
   }
 
-  return new Response(value)
+  if (response === null) {
+    return new Response("Not found", { status: 404 })
+  }
+
+  return new Response(response)
 }


### PR DESCRIPTION
Adds discard records for A and AAAA which indicate to Cloudflare to route to the worker.

Updated worker to check path and respond 404 to all other requests that aren't `/.well-known/mta-sts.txt`.