### PR TITLE
Remove extraneous : from IPv6 address

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -28,7 +28,7 @@ resource "cloudflare_record" "aaaa" {
   zone_id = var.zone_id
   name    = "mta-sts"
   type    = "AAAA"
-  value   = "100:::"
+  value   = "100::"
 }
 
 resource "cloudflare_workers_kv_namespace" "mta_sts" {


### PR DESCRIPTION
An additional `:` causes the deployment to fail during testing.