### PR TITLE
Update required status for mode and max_age

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,9 +42,9 @@ module {
 |------|-------------|------|:--------:|
 | zone_id | Cloudflare Zone ID | `string` | yes |
 | zone_name | Cloudflare Zone Name | `string` | yes |
-| mode | Sending MTA policy application, [rfc8461#section-5](https://tools.ietf.org/html/rfc8461#section-5).  Default `testing` | `string` | yes |
+| mode | Sending MTA policy application, [rfc8461#section-5](https://tools.ietf.org/html/rfc8461#section-5).  Default `testing` | `string` | no |
 | mx | List of permitted MX hosts, at least one | `list(string)` | yes |
-| max_age | Maximum lifetime of the policy in seconds, up to 31557600, defaults to 604800 (1 week) | `number` | yes |
+| max_age | Maximum lifetime of the policy in seconds, up to 31557600, defaults to 604800 (1 week) | `number` | no |
 | rua | Locations to which aggregate reports about policy violations should be sent, either `mailto:` or `https:` schema. | `list(string)` | yes |
 
 ## Outputs


### PR DESCRIPTION
Closes #6

`mode` and `max_age` were incorrectly reported as required when they have default values set.

This PR updates the README documentation for the module to indicate they are not required.