### PR TITLE
Ignore route_id changes

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -65,4 +65,10 @@ resource "cloudflare_workers_route" "mta_sts" {
   zone_id = var.zone_id
   pattern = "mta-sts.${var.zone_name}/*"
   script  = cloudflare_workers_script.mta_sts_policy.script_name
+
+  lifecycle {
+    ignore_changes = [
+      route_id
+    ]
+  }
 }


### PR DESCRIPTION
`route_id` doesn't appear to be set, perhaps ignoring the changes in lifecycle might prevent replacement.  This is due to the v4 to v5 migration in Cloudflare provider.