### PR TITLE
chore: add GitHub FUNDING configuration

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: rsclarke
+thanks_dev: u/gh/rsclarke


### PR DESCRIPTION
Adds GitHub FUNDING.yml to display sponsorship options on the repository.