### PR TITLE
chore: harden GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,5 @@ updates:
       day: "friday"
       time: "08:00"
       timezone: "Australia/Perth"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,11 +4,16 @@ on:
     branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
       - uses: rsclarke/setup-tenv@3d18295597c070746e3af675a40415f65359a411 # v2.1.0
         with:
           tool: terraform

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,13 @@ on:
 permissions:
   contents: read
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   check:
+    name: Check Terraform
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,28 @@
+name: Run zizmor
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  zizmor:
+    name: Run zizmor
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # Required for zizmor-action to upload SARIF to GitHub code scanning.
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@5f14fd08f7cf1cb1609c1e344975f152c7ee938d # v0.5.6


### PR DESCRIPTION
This PR hardens the repository's GitHub Actions surface and adds ongoing zizmor auditing after resolving existing local findings.

- Hardened the existing CI workflow with read-only contents permissions, `persist-credentials: false` for checkout, a named job, and concurrency cancellation for superseded runs.
- Hardened Dependabot by adding a seven-day cooldown for GitHub Actions updates.
- Added `.github/workflows/zizmor.yml` to run zizmor on pull requests and pushes to `main` with least-privilege permissions and pinned action SHAs.
- Validation: `zizmor --strict-collection .` passed with no findings.
- Validation: `zizmor --persona=auditor .` passed with no findings.
- Inline ignores: none added.
- Policy decisions: preserved the repo's existing immutable SHA-pinning style for actions; kept `security-events: write` in the zizmor job because `zizmor-action` uploads SARIF to GitHub code scanning.
